### PR TITLE
Add a playbook for machine bootstrapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/inventory.yml

--- a/bootstrap-playbook.yml
+++ b/bootstrap-playbook.yml
@@ -1,0 +1,59 @@
+---
+- name: Set up servers for Ansible
+  hosts: bootstrap
+  become: yes
+  vars:
+    ssh_user: "{{ lookup('env', 'ANSIBLE_SSH_USER') }}"
+    ssh_port: "{{ lookup('env', 'ANSIBLE_SSH_PORT') }}"
+    ssh_key:  "{{ lookup('env', 'ANSIBLE_SSH_KEY') }}"
+  tasks:
+    - name: Ensure ansible user exists
+      user:
+        name: "{{ ssh_user }}"
+        home: "/var/lib/{{ ssh_user }}"
+        system: yes
+
+    - name: Ensure packages are up to date (Debian)
+      when: ansible_distribution == "Debian"
+      apt:
+        update_cache: yes
+        upgrade: dist
+
+    - name: Ensure sudo package is installed (Debian)
+      when: ansible_distribution == "Debian"
+      apt:
+        name: sudo
+
+    - name: Ensure ansible user can become root w/o passwd
+      lineinfile:
+        path: /etc/sudoers
+        line: "{{ ssh_user }} ALL=(ALL) NOPASSWD:ALL"
+        validate: "visudo -cf %s"
+
+    - name: Ensure SSH pubkey is authorized for configured user
+      authorized_key:
+        user: "{{ ssh_user }}"
+        key: "{{ ssh_key }}"
+
+    - name: Ensure SSH daemon listens on configured port
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        regexp: ^Port
+        line: "Port {{ ssh_port }}"
+      notify: Restart SSH daemon
+
+    - name: Remove host from bootstrap group
+      shell: |
+        vars='{"ansible_user":"{{ ssh_user }}","ansible_port":{{ ssh_port }}}'
+        addExpr=".all.hosts.{{ inventory_hostname }} += $vars"
+        delExpr='del(.all.children.bootstrap.hosts.{{ inventory_hostname }})'
+        yq -y "$addExpr" {{ inventory_file }} > {{ inventory_file }}.tmp
+        yq -y "$delExpr" {{ inventory_file }}.tmp > {{ inventory_file }}
+      delegate_to: 127.0.0.1
+      become: no
+
+  handlers:
+    - name: Restart SSH daemon
+      service:
+        name: sshd
+        state: restarted

--- a/bootstrap-playbook.yml
+++ b/bootstrap-playbook.yml
@@ -49,6 +49,7 @@
         delExpr='del(.all.children.bootstrap.hosts.{{ inventory_hostname }})'
         yq -y "$addExpr" {{ inventory_file }} > {{ inventory_file }}.tmp
         yq -y "$delExpr" {{ inventory_file }}.tmp > {{ inventory_file }}
+        rm {{ inventory_file }}.tmp
       delegate_to: 127.0.0.1
       become: no
 


### PR DESCRIPTION
Add a playbook that sets up machines for use with Ansible. This playbook should set up a user for Ansible, copy a public SSH key to its list of authorized keys, and make it so it can become `root` without having to input any passwords (as there wouldn't be passwords anyway).

Since this playbook also changes the SSH port to a desired one as set through environment variables, it relies on a group called `bootstrap`, from which hosts will be removed later on, while the new port used for SSH and the user that was created will be added as facts to the inventory file.

It would be better to track the inventory through Git, as well, but for privacy's sake this is not being done in a public repository.

Lastly: this playbook should be executed before any others, but that is not strictly necessary. The playbook itself is idempotent, as well, even when hosts are manually added back to the `bootstrap` group. As long as the port that was set for it remains and Ansible can log into the server, that is.

**Dependencies:** this playbook depends on [kislyuk/yq](https://github.com/kislyuk/yq), a wrapper around `jq`.