### PR TITLE
Allow sudo group to sudo w/o passwd

### DIFF
--- a/bootstrap-playbook.yml
+++ b/bootstrap-playbook.yml
@@ -30,6 +30,13 @@
         line: "{{ ssh_user }} ALL=(ALL) NOPASSWD:ALL"
         validate: "visudo -cf %s"
 
+    - name: Ensure sudo group can become root w/o passwd
+      lineinfile:
+        path: /etc/sudoers
+        regexp: '^%sudo'
+        line: "%sudo ALL=(ALL) NOPASSWD:ALL"
+        validate: "visudo -cf %s"
+
     - name: Ensure SSH pubkey is authorized for configured user
       authorized_key:
         user: "{{ ssh_user }}"


### PR DESCRIPTION
Allow the sudo group to become root without need for a password, since it would be a hassle to manually set passwords for each user as created by the users playbook.

Note that there's no task on this repository that makes any users part of the sudo group. That is by design: allowing a user into the sudo group is a rarely performed task, so it will be carried out through ad-hoc commands.