### PR TITLE
Add some more essential tools, including Docker Compose

### DIFF
--- a/essentials-playbook.yml
+++ b/essentials-playbook.yml
@@ -1,4 +1,14 @@
 ---
+- name: Ensure all packages are up to date
+  hosts: all
+  become: yes
+  tasks:
+    - name: Update all packages (Debian)
+      when: ansible_distribution == "Debian"
+      apt:
+        update_cache: yes
+        upgrade: full
+
 - name: Ensure Docker Engine is installed
   hosts: all
   become: yes

--- a/essentials-playbook.yml
+++ b/essentials-playbook.yml
@@ -16,12 +16,7 @@
     - name: Ensure dependencies are installed (Debian)
       when: ansible_distribution == "Debian"
       apt:
-        name:
-          - apt-transport-https
-          - ca-certificates
-          - curl
-          - gnupg-agent
-          - software-properties-common
+        name: ca-certificates, curl, gpg-agent, software-properties-common
         state: latest
         update_cache: yes
 

--- a/essentials-playbook.yml
+++ b/essentials-playbook.yml
@@ -59,5 +59,5 @@
     - name: Ensure essential tools are installed (Debian)
       when: ansible_distribution == "Debian"
       apt:
-        name: mosh, tree, tmux, neovim
+        name: zsh, mosh, tree, tmux, neovim, rsync, ncdu, htop, git
         update_cache: yes

--- a/essentials-playbook.yml
+++ b/essentials-playbook.yml
@@ -22,6 +22,7 @@
           - curl
           - gnupg-agent
           - software-properties-common
+        state: latest
         update_cache: yes
 
     - name: Ensure Docker PGP key is in APT keyring
@@ -38,6 +39,7 @@
       when: ansible_distribution == "Debian"
       apt:
         name: docker-ce, docker-ce-cli, containerd.io
+        state: latest
 
     - name: Ensure the Docker service is enabled and started
       service:
@@ -52,14 +54,14 @@
     - name: Ensure Python 3 is installed (Debian)
       when: ansible_distribution == "Debian"
       apt:
-        name:
-          - python3
-          - python3-pip
+        name: python3, python3-pip
+        state: latest
         update_cache: yes
 
     - name: Ensure Beets is installed globally
       pip:
         executable: pip3
+        state: latest
         name: beets
 
 - name: Ensure essential tools are installed
@@ -70,4 +72,5 @@
       when: ansible_distribution == "Debian"
       apt:
         name: zsh, mosh, tree, tmux, neovim, rsync, ncdu, htop, git
+        state: latest
         update_cache: yes

--- a/essentials-playbook.yml
+++ b/essentials-playbook.yml
@@ -42,6 +42,22 @@
         state: started
         enabled: yes
 
+- name: Ensure Docker Compose (V1) is installed
+  hosts: all
+  become: yes
+  tasks:
+    - name: Ensure Python 3 is installed (Debian)
+      when: ansible_distribution == "Debian"
+      apt:
+        name: python3, python3-pip
+        state: latest
+        update_cache: yes
+
+    - name: Ensure docker-compose is installed through pip
+      pip:
+        name: docker-compose
+        state: latest
+
 - name: Ensure Beets is installed
   hosts: storage
   become: yes


### PR DESCRIPTION
Make some changes to the essential tools playbook, including a play that ensures Docker Compose (V1) is installed as well as adding more packages (e.g. `zsh`) to the last play on the book.