### PR TITLE
Make ZSH the default shell for users

### DIFF
--- a/users.yml
+++ b/users.yml
@@ -37,6 +37,7 @@
       with_items: "{{ desired_users }}"
       user:
         name: "{{ item }}"
+        shell: /bin/zsh
 
     - name: Ensure leftover users are removed
       with_items: "{{ current_users | difference(desired_users) }}"


### PR DESCRIPTION
Make zsh the default shell for every user being added to the hosts.

The essentials playbook will ensure that zsh is installed, so there's little fear that users will end up unable to login.
