### PR TITLE
Add firewalld set up to bootstrap process

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,3 +1,6 @@
 [defaults]
 inventory = inventory.yml
 nocows    = True
+
+[ssh_connection]
+pipelining = True

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -24,6 +24,27 @@
       apt:
         name: sudo
 
+    - name: Ensure firewall is activated and SSH enabled
+      block:
+        - name: Ensure firewalld is installed (Debian)
+          when: ansible_distribution == "Debian"
+          apt:
+            name: firewalld
+            state: latest
+
+        - name: Ensure configured SSH port is open through firewalld
+          firewalld:
+            port: '{{ ssh_port }}/tcp'
+            permanent: true
+            immediate: true
+            state: enabled
+
+        - name: Ensure firewalld service is enabled & started
+          service:
+            name: firewalld
+            enabled: true
+            state: started
+
     - name: Ensure ansible user can become root w/o passwd
       lineinfile:
         path: /etc/sudoers

--- a/essentials.yml
+++ b/essentials.yml
@@ -85,3 +85,10 @@
         name: zsh, mosh, tree, tmux, neovim, rsync, ncdu, htop, git, tmuxinator
         state: latest
         update_cache: yes
+
+    - name: Ensure mosh's UDP ports are open (firewalld)
+      firewalld:
+        port: 60000-61000/udp
+        permanent: true
+        immediate: true
+        state: enabled


### PR DESCRIPTION
Set up `firewalld` during the bootstrap process, enabling the SSH port so we're
not blocked from accessing the host. Moreover, enable mosh's UDP port range
after installation.

More services later on will need to have their ports enabled through firewalld.
A playbook with a general task that retrieves a list of ports to enabled might
soon be added.

Pipelining was enabled to try and reuse a single SSH connection and avoid
firewalld prohibiting access to the task that enables the SSH port.

Closes #11.
