### PR TITLE
Limit bootstrap inventory change to 1 host at a time

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -80,6 +80,7 @@
         rm {{ inventory_file }}.tmp
       delegate_to: 127.0.0.1
       become: no
+      throttle: 1
 
   handlers:
     - name: Restart SSH daemon


### PR DESCRIPTION
Throttle modifying the inventory file so it's done completely for one host at a time, preventing errors caused by manipulating the same files at roughly the same time.

Closes #15.
