### PR TITLE
Add CD workflow that runs on a schedule

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,37 @@
+name: CD
+
+on:
+  push:
+    branches: [ master ]
+  schedule:
+    - cron: '*/5 * * * *'
+
+jobs:
+  ansible:
+    name: Playbook
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        playbook:
+          - essentials.yml
+          - users.yml
+
+    steps:
+      - name: Checkout files in the repository
+        uses: actions/checkout@v2
+
+      - name: Retrieve the inventory from GH secrets
+        env:
+          INVENTORY_B64: ${{ secrets.ANSIBLE_INVENTORY }}
+        run: |
+          echo "$INVENTORY_B64" | base64 -d > inventory.yml
+
+      - name: Run playbook
+        uses: dawidd6/action-ansible-playbook@v2
+        with:
+          playbook: ${{ matrix.playbook }}
+          key: ${{ secrets.ANSIBLE_SSH_PRIVATE_KEY }}
+
+      - name: Remove inventory file
+        run: rm inventory.yml


### PR DESCRIPTION
Add a continuous deployment workflow that will run playbooks other than the bootstrap playbook at every push to master and every 5 minutes.
