### PR TITLE
Increase CD workflow backoff

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master ]
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: '*/15 * * * *'
 
 jobs:
   ansible:


### PR DESCRIPTION
Set the CD workflow to run only every 15 minutes. Hopefully this isn't too excessive for GitHub and it'll more or less run on schedule.
