### PR TITLE
Ensure fail2ban is installed & enabled

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -25,6 +25,19 @@
       apt:
         name: sudo
 
+    - name: Ensure fail2ban is installed and enabled
+      block:
+        - name: Ensure fail2ban is installed (Debian)
+          when: ansible_distribution == "Debian"
+          apt:
+            name: fail2ban
+
+        - name: Ensure fail2ban service is enabled & started
+          service:
+            name: fail2ban
+            enabled: true
+            state: started
+
     - name: Ensure firewall is activated and SSH enabled
       block:
         - name: Ensure firewalld is installed (Debian)


### PR DESCRIPTION
On distributions such as Debian, fail2ban will come with predefined
filters, actions and jails. There is no need for further configuration
if all we want is to protect SSH.

Other services, when deployed, might include filters of their own.

Closes #23.
